### PR TITLE
Made Travis run our tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: python
 python:
   - 3.6
+services:
+  - postgresql
+before_script:
+  - psql -c 'CREATE DATABASE travis_ci_test;' -U postgres
+test:
+  adapter: postgresql
+  database: travis_ci_test
 install: 
   - pip install -r requirements.txt
   - cd frontend

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ install:
   - cd frontend
   - npm install
 script:
-  - npm run lint-js
-  - npm run lint-css
+  - npm run lint
   - cd ../
   - flake8 backend/api backend/data
   - isort -c
+  - python manage.py test
 notifications:
   email: false

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -35,6 +35,22 @@ Debug = True
 ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
 
 
+# Database definition for Travis
+
+if 'TRAVIS' in os.environ:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': 'orm',
+            'HOST': 'localhost',
+            'PORT': '',
+            # Replace with your own settings
+            'USER': 'username',
+            'PASSWORD': 'password',
+        }
+    }
+
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -41,12 +41,7 @@ if 'TRAVIS' in os.environ:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            'NAME': 'orm',
-            'HOST': 'localhost',
-            'PORT': '',
-            # Replace with your own settings
-            'USER': 'username',
-            'PASSWORD': 'password',
+            'NAME': 'travis_ci_test',
         }
     }
 


### PR DESCRIPTION
We somehow missed this, or knew that we missed it and didn't bother to fix it. So here's a fix!
Will now run `python manage.py test`on every PR and push, so we don't goof our functionality and actually get some use of our tests.